### PR TITLE
Big endian parser

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "Unity"]
-	path = Unity
-	url = https://github.com/ThrowTheSwitch/Unity.git
 [submodule "lib/Unity"]
 	path = lib/Unity
 	url = https://github.com/ThrowTheSwitch/Unity.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 project(svm)
 set(CMAKE_C_STANDARD 99)
 
+INCLUDE(TestBigEndian)
+
 add_subdirectory(src)
 add_subdirectory(test)
 add_subdirectory(lib)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ add_library(vm-lib STATIC
     vm/vm.h
     vm/vmstring.c
     vm/vmstring.h
+    vm/math.h
+    vm/math.c
 )
 
 target_include_directories(vm-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,5 +34,5 @@ target_link_libraries(vm vm-lib)
 TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
 
 IF(NOT ${IS_BIG_ENDIAN})
-    add_compile_options(-D VM_IS_LITTLE_ENDIAN)
+    add_definitions( -DVM_IS_LITTLE_ENDIAN )
 ENDIF()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -23,8 +23,16 @@ add_library(vm-lib STATIC
     vm/vmstring.h
     vm/math.h
     vm/math.c
+    vm/bytecode.h
+    vm/bytecode.c
 )
 
 target_include_directories(vm-lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 add_executable(vm main.c)
 target_link_libraries(vm vm-lib)
+
+TEST_BIG_ENDIAN(IS_BIG_ENDIAN)
+
+IF(NOT ${IS_BIG_ENDIAN})
+    add_compile_options(-D VM_IS_LITTLE_ENDIAN)
+ENDIF()

--- a/src/main.c
+++ b/src/main.c
@@ -7,49 +7,27 @@
 #include <vm/opcode.h>
 #include <vm/vm.h>
 
-
 int main(int argc, char const* argv[])
 {
-    // char exe[] = {
-    //     39, 0, 0, 0, // PROGRAM START POS
-    //     49, 0, 0, 0,
-    //     // CONSTANTS
-    //     6, 0, // LEN
-    //     72, 101, 108, 108, 111, 32, // STR VAL
-    //     6, 0, // LEN
-    //     119, 111, 114, 108, 100, 33, // STR VAL
-    //     0, 0, // NEW LEN
-    //     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // FUTURE STR VAL
-    //     // PROGRAM START
-    //     OP_I_PUSH, 0, 0,
-    //     OP_I_PUSH, 8, 0,
-    //     OP_S_CAT, 16, 0,
-    //     OP_S_PRINT, 16, 0,
-    //     OP_HALT
-    // };
-
     char exe[] = {
-        63, 0, 0, 0, 0, 0, 0, 0, // EXE LEN
-        16, 0, 0, 0, 0, 0, 0, 0, // CONSTS LEN
+        0, 0, 0, 0, 0, 0, 0, 63, // EXE LEN
+        0, 0, 0, 0, 0, 0, 0, 16, // CONSTS LEN
         // CONSTANTS
-        6, 0, // LEN
+        0, 6, // LEN
         72, 101, 108, 108, 111, 32, // STR VAL (Hello )
-        6, 0, // LEN
+        0, 6, // LEN
         119, 111, 114, 108, 100, 33, // STR VAL (world!)
         // PROGRAM START
-        OP_P_PUSH, 0,
+        0, OP_P_PUSH,
         0, 0, 0, 0, // Push ptr 0
-        OP_P_PUSH, 0,
-        8, 0, 0, 0, // Push ptr 8
-        OP_ALLOC, 0,
-        32, 0, 0, 0, 0, 0, 0, 0, // 32 bytes: size of Hello world!
+        0, OP_P_PUSH,
+        0, 0, 0, 8, // Push ptr 8
+        0, OP_ALLOC,
+        0, 0, 0, 0, 0, 0, 0, 32, // 32 bytes: size of Hello world!
         // Now our storage pointer is on the stack, we are ready to call string cat
-        OP_S_CAT, 0, // String cat returns the storage pointer onto the stack
-        OP_S_PRINT, 0,
-        OP_HALT, 0,
-        OP_S_PRINT, 0,
-        // Str @ ptr
-        OP_HALT, 0
+        0, OP_S_CAT, // String cat returns the storage pointer onto the stack
+        0, OP_S_PRINT,
+        0, OP_HALT
     };
 
     EXECUTABLE executable = executable_from(&exe);

--- a/src/main.c
+++ b/src/main.c
@@ -27,12 +27,11 @@ int main(int argc, char const* argv[])
         // Now our storage pointer is on the stack, we are ready to call string cat
         0, OP_S_CAT, // String cat returns the storage pointer onto the stack
         0, OP_S_PRINT,
-        0, OP_HALT
+        0, OP_HALT, 0, 0
     };
 
     EXECUTABLE executable = executable_from(&exe);
-
-    VM vm = vm_create(executable);
+    VM         vm         = vm_create(executable);
 
     int16_t exit_code = vm_run(&vm);
 

--- a/src/vm/bytecode.c
+++ b/src/vm/bytecode.c
@@ -1,0 +1,68 @@
+#include "bytecode.h"
+#include "math.h"
+
+OPCODE bytecode_read_opcode(STREAM* program)
+{
+    OPCODE value = *((OPCODE*)stream_advance(program, sizeof(OPCODE)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return (OPCODE)math_int16_to_big_endian(value);
+#else
+    return value;
+#endif
+}
+
+INTEGER bytecode_read_int(STREAM* program)
+{
+    INTEGER value = *((INTEGER*)stream_advance(program, sizeof(INTEGER)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return math_int16_to_big_endian(value);
+#else
+    return value;
+#endif
+}
+
+UINTEGER bytecode_read_uint(STREAM* program)
+{
+    UINTEGER value = *((UINTEGER*)stream_advance(program, sizeof(UINTEGER)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return (UINTEGER)math_int16_to_big_endian(value);
+#else
+    return value;
+#endif
+}
+
+LONG bytecode_read_long(STREAM* program)
+{
+    LONG value = *((LONG*)stream_advance(program, sizeof(LONG)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return math_int64_to_big_endian(value);
+#else
+    return value;
+#endif
+}
+
+ULONG bytecode_read_ulong(STREAM* program)
+{
+    ULONG value = *((ULONG*)stream_advance(program, sizeof(ULONG)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return (ULONG)math_int64_to_big_endian(value);
+#else
+    return value;
+#endif
+}
+
+POINTER bytecode_read_ptr(STREAM* program)
+{
+    POINTER value = *((POINTER*)stream_advance(program, sizeof(POINTER)));
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    return math_int32_to_big_endian(value);
+#else
+    return value;
+#endif
+}

--- a/src/vm/bytecode.h
+++ b/src/vm/bytecode.h
@@ -1,0 +1,14 @@
+#ifndef BYTECODE_H
+#define BYTECODE_H
+
+#include "stream.h"
+#include "type.h"
+
+OPCODE   bytecode_read_opcode(STREAM* program);
+INTEGER  bytecode_read_int(STREAM* program);
+UINTEGER bytecode_read_uint(STREAM* program);
+LONG     bytecode_read_long(STREAM* program);
+ULONG    bytecode_read_ulong(STREAM* program);
+POINTER  bytecode_read_ptr(STREAM* program);
+
+#endif /* BYTECODE_H */

--- a/src/vm/executable.c
+++ b/src/vm/executable.c
@@ -1,25 +1,39 @@
 #include "executable.h"
+#include "math.h"
 #include "opcode.h"
 #include "stream.h"
 #include <string.h>
 
 EXECUTABLE executable_from(char* bytes)
 {
-    EXECUTABLE_HEADER* header           = (EXECUTABLE_HEADER*)bytes;
-    void*              constants        = malloc(header->constants_length);
-    size_t             constants_offset = sizeof(EXECUTABLE_HEADER);
-    memcpy(constants, bytes + constants_offset, header->constants_length);
+    EXECUTABLE_HEADER header = executable_read_header(bytes);
 
-    size_t program_size   = header->executable_length - header->constants_length - sizeof(EXECUTABLE_HEADER);
+    void*  constants        = malloc(header.constants_length);
+    size_t constants_offset = sizeof(EXECUTABLE_HEADER);
+    memcpy(constants, bytes + constants_offset, header.constants_length);
+
+    size_t program_size   = header.executable_length - header.constants_length - sizeof(EXECUTABLE_HEADER);
     void*  program        = malloc(program_size);
-    size_t program_offset = constants_offset + header->constants_length;
+    size_t program_offset = constants_offset + header.constants_length;
     memcpy(program, bytes + program_offset, program_size);
 
     EXECUTABLE executable;
-    executable.constants = constants_create(constants, header->constants_length);
+    executable.constants = constants_create(constants, header.constants_length);
     executable.program   = stream_create(program, program_size);
 
     return executable;
+}
+
+EXECUTABLE_HEADER executable_read_header(char* bytes)
+{
+    EXECUTABLE_HEADER header = *((EXECUTABLE_HEADER*)bytes);
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    header.constants_length  = (ULONG)math_int64_to_big_endian(header.constants_length);
+    header.executable_length = (ULONG)math_int64_to_big_endian(header.executable_length);
+#endif
+
+    return header;
 }
 
 void executable_free(EXECUTABLE executable)

--- a/src/vm/executable.h
+++ b/src/vm/executable.h
@@ -17,6 +17,8 @@ typedef struct EXECUTABLE_T {
 
 EXECUTABLE executable_from(char* bytes);
 
+EXECUTABLE_HEADER executable_read_header(char* bytes);
+
 void executable_free(EXECUTABLE executable);
 
 #endif /* EXECUTABLE_H */

--- a/src/vm/executor.c
+++ b/src/vm/executor.c
@@ -123,8 +123,9 @@ STATE op_scat(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 
 STATE op_sprint(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    POINTER          str_ptr = stack_pop(stack).ptr_val;
-    VMSTRING_HEADER* str     = (VMSTRING_HEADER*)heap_at(heap, str_ptr);
+    POINTER str_ptr = stack_pop(stack).ptr_val;
+
+    VMSTRING_HEADER* str = (VMSTRING_HEADER*)heap_at(heap, str_ptr);
 
     char* data = vmstring_data_ptr(str);
     for (int i = 0; i < str->length; i++) {

--- a/src/vm/executor.c
+++ b/src/vm/executor.c
@@ -1,4 +1,5 @@
 #include "executor.h"
+#include "bytecode.h"
 #include "opcode.h"
 #include "vmstring.h"
 #include <stdio.h>
@@ -6,7 +7,7 @@
 
 STATE op_loadarg(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    INTEGER offset   = *((INTEGER*)stream_advance(program, sizeof(INTEGER)));
+    INTEGER offset   = bytecode_read_int(program);
     INTEGER position = state.frame_position + offset;
     OBJECT  o        = stack_at(stack, position);
 
@@ -19,8 +20,8 @@ STATE op_loadarg(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 
 STATE op_call(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    POINTER  fun_addr = *((POINTER*)stream_advance(program, sizeof(POINTER)));
-    UINTEGER num_args = *((UINTEGER*)stream_advance(program, sizeof(UINTEGER)));
+    POINTER  fun_addr = bytecode_read_ptr(program);
+    UINTEGER num_args = bytecode_read_uint(program);
 
     POINTER return_addr = stream_position(program);
 
@@ -53,7 +54,7 @@ STATE op_return(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 
 STATE op_halt(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    INTEGER exit_code = *((INTEGER*)stream_advance(program, sizeof(INTEGER)));
+    INTEGER exit_code = bytecode_read_int(program);
 
     state.running   = false;
     state.exit_code = exit_code;
@@ -73,7 +74,7 @@ STATE op_print(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 // Pointer operations
 STATE op_ppush(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    POINTER pointer = *((POINTER*)stream_advance(program, sizeof(POINTER)));
+    POINTER pointer = bytecode_read_ptr(program);
 
     stack_push(stack, object_of_ptr(pointer));
 
@@ -84,7 +85,7 @@ STATE op_ppush(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 
 STATE op_alloc(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    ULONG   alloc_size = *((ULONG*)stream_advance(program, sizeof(ULONG)));
+    ULONG   alloc_size = bytecode_read_ulong(program);
     POINTER ptr        = heap_alloc(heap, alloc_size);
 
     stack_push(stack, object_of_ptr(ptr));
@@ -135,7 +136,7 @@ STATE op_sprint(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 
 STATE op_ipush(STACK* stack, STREAM* program, HEAP* heap, STATE state)
 {
-    INTEGER value = *((INTEGER*)stream_advance(program, sizeof(INTEGER)));
+    INTEGER value = bytecode_read_int(program);
 
     stack_push(stack, object_of_int(value));
 

--- a/src/vm/math.c
+++ b/src/vm/math.c
@@ -1,33 +1,33 @@
 #include "math.h"
 
-INTEGER math_int_to_big_endian(INTEGER i)
+int16_t math_int16_to_big_endian(int16_t i)
 {
-    INTEGER b0 = (i & 0xff00) >> 8;
-    INTEGER b1 = (i & 0xff) << 8;
+    int16_t b0 = (i & 0xff00) >> 8;
+    int16_t b1 = (i & 0xff) << 8;
 
     return b0 | b1;
 }
 
-LONG math_long_to_big_endian(LONG l)
+int64_t math_int64_to_big_endian(int64_t l)
 {
-    LONG b0 = (l & 0xff00000000000000) >> 56;
-    LONG b1 = (l & 0xff000000000000) >> 40;
-    LONG b2 = (l & 0xff0000000000) >> 24;
-    LONG b3 = (l & 0xff00000000) >> 8;
-    LONG b4 = (l & 0xff000000) << 8;
-    LONG b5 = (l & 0xff0000) << 24;
-    LONG b6 = (l & 0xff00) << 40;
-    LONG b7 = (l & 0xff) << 56;
+    int64_t b0 = (l & 0xff00000000000000) >> 56;
+    int64_t b1 = (l & 0xff000000000000) >> 40;
+    int64_t b2 = (l & 0xff0000000000) >> 24;
+    int64_t b3 = (l & 0xff00000000) >> 8;
+    int64_t b4 = (l & 0xff000000) << 8;
+    int64_t b5 = (l & 0xff0000) << 24;
+    int64_t b6 = (l & 0xff00) << 40;
+    int64_t b7 = (l & 0xff) << 56;
 
     return b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7;
 }
 
-POINTER math_ptr_to_big_endian(POINTER ptr)
+int32_t math_int32_to_big_endian(int32_t ptr)
 {
-    POINTER b0 = (ptr & 0xff000000) >> 24;
-    POINTER b1 = (ptr & 0xff0000) >> 8;
-    POINTER b2 = (ptr & 0xff00) << 8;
-    POINTER b3 = (ptr & 0xff) << 24;
+    int32_t b0 = (ptr & 0xff000000) >> 24;
+    int32_t b1 = (ptr & 0xff0000) >> 8;
+    int32_t b2 = (ptr & 0xff00) << 8;
+    int32_t b3 = (ptr & 0xff) << 24;
 
     return b0 | b1 | b2 | b3;
 }

--- a/src/vm/math.c
+++ b/src/vm/math.c
@@ -1,0 +1,33 @@
+#include "math.h"
+
+INTEGER math_int_to_big_endian(INTEGER i)
+{
+    INTEGER b0 = (i & 0xff00) >> 8;
+    INTEGER b1 = (i & 0xff) << 8;
+
+    return b0 | b1;
+}
+
+LONG math_long_to_big_endian(LONG l)
+{
+    LONG b0 = (l & 0xff00000000000000) >> 56;
+    LONG b1 = (l & 0xff000000000000) >> 40;
+    LONG b2 = (l & 0xff0000000000) >> 24;
+    LONG b3 = (l & 0xff00000000) >> 8;
+    LONG b4 = (l & 0xff000000) << 8;
+    LONG b5 = (l & 0xff0000) << 24;
+    LONG b6 = (l & 0xff00) << 40;
+    LONG b7 = (l & 0xff) << 56;
+
+    return b0 | b1 | b2 | b3 | b4 | b5 | b6 | b7;
+}
+
+POINTER math_ptr_to_big_endian(POINTER ptr)
+{
+    POINTER b0 = (ptr & 0xff000000) >> 24;
+    POINTER b1 = (ptr & 0xff0000) >> 8;
+    POINTER b2 = (ptr & 0xff00) << 8;
+    POINTER b3 = (ptr & 0xff) << 24;
+
+    return b0 | b1 | b2 | b3;
+}

--- a/src/vm/math.h
+++ b/src/vm/math.h
@@ -1,10 +1,10 @@
 #ifndef MATH_H
 #define MATH_H
 
-#include "type.h"
+#include <stdint.h>
 
-INTEGER math_int_to_big_endian(INTEGER i);
-LONG    math_long_to_big_endian(LONG l);
-POINTER math_ptr_to_big_endian(POINTER ptr);
+int16_t math_int16_to_big_endian(int16_t i);
+int64_t math_int64_to_big_endian(int64_t l);
+int32_t math_int32_to_big_endian(int32_t ptr);
 
 #endif /* MATH_H */

--- a/src/vm/math.h
+++ b/src/vm/math.h
@@ -1,0 +1,10 @@
+#ifndef MATH_H
+#define MATH_H
+
+#include "type.h"
+
+INTEGER math_int_to_big_endian(INTEGER i);
+LONG    math_long_to_big_endian(LONG l);
+POINTER math_ptr_to_big_endian(POINTER ptr);
+
+#endif /* MATH_H */

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -2,7 +2,6 @@
 #include "bytecode.h"
 #include "executor.h"
 
-
 VM vm_create(EXECUTABLE executable)
 {
     VM vm;

--- a/src/vm/vm.c
+++ b/src/vm/vm.c
@@ -1,5 +1,7 @@
 #include "vm.h"
+#include "bytecode.h"
 #include "executor.h"
+
 
 VM vm_create(EXECUTABLE executable)
 {
@@ -33,7 +35,7 @@ INTEGER vm_run(VM* vm)
     while (vm->state.running) {
         stream_seek(&vm->program, vm->state.instruction_ptr);
 
-        OPCODE opcode = *((OPCODE*)stream_advance(&vm->program, sizeof(OPCODE)));
+        OPCODE opcode = bytecode_read_opcode(&vm->program);
 
         vm->state.instruction_ptr += sizeof(OPCODE);
         vm->state = vm->executors[opcode](&vm->stack, &vm->program, &vm->heap, vm->state);

--- a/src/vm/vmstring.c
+++ b/src/vm/vmstring.c
@@ -1,17 +1,32 @@
 #include "vmstring.h"
+#include "math.h"
 #include <string.h>
 
 void vmstring_concat(VMSTRING_HEADER* a, VMSTRING_HEADER* b, VMSTRING_HEADER* out)
 {
-    ULONG new_len = a->length + b->length; // TODO maybe check for overflow?
+    VMSTRING_HEADER a_header = vmstring_read_header(a);
+    VMSTRING_HEADER b_header = vmstring_read_header(b);
+
+    ULONG new_len = a_header.length + b_header.length; // TODO maybe check for overflow?
 
     out->length = new_len;
 
     void* a_string_offset = vmstring_data_ptr(out);
-    void* b_string_offset = a_string_offset + a->length;
+    void* b_string_offset = a_string_offset + a_header.length;
 
-    memcpy(a_string_offset, vmstring_data_ptr(a), a->length);
-    memcpy(b_string_offset, vmstring_data_ptr(b), b->length);
+    memcpy(a_string_offset, vmstring_data_ptr(a), a_header.length);
+    memcpy(b_string_offset, vmstring_data_ptr(b), b_header.length);
+}
+
+VMSTRING_HEADER vmstring_read_header(void* str_ptr)
+{
+    VMSTRING_HEADER header = *((VMSTRING_HEADER*)str_ptr);
+
+#ifdef VM_IS_LITTLE_ENDIAN
+    header.length = (INTEGER)math_int16_to_big_endian(header.length);
+#endif
+
+    return header;
 }
 
 void* vmstring_data_ptr(VMSTRING_HEADER* str)

--- a/src/vm/vmstring.h
+++ b/src/vm/vmstring.h
@@ -9,6 +9,8 @@ typedef struct VMSTRING_HEADER_T {
 
 void vmstring_concat(VMSTRING_HEADER* a, VMSTRING_HEADER* b, VMSTRING_HEADER* out);
 
+VMSTRING_HEADER vmstring_read_header(void*);
+
 void* vmstring_data_ptr(VMSTRING_HEADER* str);
 
 #endif /* VMSTRING_H */

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,3 +8,4 @@ endmacro()
 
 vm_add_test(test_heap)
 vm_add_test(test_math)
+vm_add_test(test_bytecode)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,7 +1,10 @@
 enable_testing()
 
-add_executable(vm-test test_heap.c)
- 
-target_link_libraries(vm-test vm-lib unity)
- 
-add_test(heap-tests vm-test)
+macro(vm_add_test name)
+    add_executable(${name} ${name}.c ${ARGN})
+    target_link_libraries(${name} vm-lib unity)
+    add_test(${name} ${name})
+endmacro()
+
+vm_add_test(test_heap)
+vm_add_test(test_math)

--- a/test/main.c
+++ b/test/main.c
@@ -1,7 +1,0 @@
-#include <stdio.h>
-#include <unity.h>
-
-int main(int argc, char const* argv[])
-{
-    printf("Hello, world! DOOT");
-}

--- a/test/test_bytecode.c
+++ b/test/test_bytecode.c
@@ -1,0 +1,82 @@
+#include <unity.h>
+#include <vm/bytecode.h>
+
+static int64_t RANDOM_NUMBERS = 0x1234567890123456;
+static STREAM  PROGRAM_OF_RANDOM_NUMBERS;
+
+void set_up()
+{
+    PROGRAM_OF_RANDOM_NUMBERS = stream_create(&RANDOM_NUMBERS, 8);
+}
+
+void before_each()
+{
+    stream_seek(&PROGRAM_OF_RANDOM_NUMBERS, 0);
+}
+
+void test_bytecode_when_read_integer_should_read_correct_amount_of_bits()
+{
+    before_each();
+    POINTER expected_pos = 2;
+
+    bytecode_read_int(&PROGRAM_OF_RANDOM_NUMBERS);
+    POINTER position = stream_position(&PROGRAM_OF_RANDOM_NUMBERS);
+
+    TEST_ASSERT_EQUAL_INT32(expected_pos, position);
+}
+
+void test_bytecode_when_read_uinteger_should_read_correct_amount_of_bits()
+{
+    before_each();
+    POINTER expected_pos = 2;
+
+    bytecode_read_uint(&PROGRAM_OF_RANDOM_NUMBERS);
+    POINTER position = stream_position(&PROGRAM_OF_RANDOM_NUMBERS);
+
+    TEST_ASSERT_EQUAL_INT32(expected_pos, position);
+}
+
+void test_bytecode_when_read_long_should_read_correct_amount_of_bits()
+{
+    before_each();
+    POINTER expected_pos = 8;
+
+    bytecode_read_long(&PROGRAM_OF_RANDOM_NUMBERS);
+    POINTER position = stream_position(&PROGRAM_OF_RANDOM_NUMBERS);
+
+    TEST_ASSERT_EQUAL_INT32(expected_pos, position);
+}
+
+void test_bytecode_when_read_ulong_should_read_correct_amount_of_bits()
+{
+    before_each();
+    POINTER expected_pos = 8;
+
+    bytecode_read_ulong(&PROGRAM_OF_RANDOM_NUMBERS);
+    POINTER position = stream_position(&PROGRAM_OF_RANDOM_NUMBERS);
+
+    TEST_ASSERT_EQUAL_INT32(expected_pos, position);
+}
+
+void test_bytecode_when_read_ptr_should_read_correct_amount_ofbits()
+{
+    before_each();
+    POINTER expected_pos = 4;
+
+    bytecode_read_ptr(&PROGRAM_OF_RANDOM_NUMBERS);
+    POINTER position = stream_position(&PROGRAM_OF_RANDOM_NUMBERS);
+
+    TEST_ASSERT_EQUAL_INT32(expected_pos, position);
+}
+
+int main(void)
+{
+    set_up();
+    UNITY_BEGIN();
+    RUN_TEST(test_bytecode_when_read_integer_should_read_correct_amount_of_bits);
+    RUN_TEST(test_bytecode_when_read_uinteger_should_read_correct_amount_of_bits);
+    RUN_TEST(test_bytecode_when_read_long_should_read_correct_amount_of_bits);
+    RUN_TEST(test_bytecode_when_read_ulong_should_read_correct_amount_of_bits);
+    RUN_TEST(test_bytecode_when_read_ptr_should_read_correct_amount_ofbits);
+    return UNITY_END();
+}

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -1,38 +1,38 @@
+#include <stdint.h>
 #include <unity.h>
 #include <vm/math.h>
-#include <vm/type.h>
 
-void test_int_to_big_endian()
+void test_int16_to_big_endian()
 {
-    INTEGER small_endian        = 0x1234;
-    INTEGER expected_big_endian = 0x3412;
+    int32_t small_endian        = 0x1234;
+    int32_t expected_big_endian = 0x3412;
 
-    INTEGER big_endian = math_int_to_big_endian(small_endian);
+    int32_t big_endian = math_int16_to_big_endian(small_endian);
 
     TEST_ASSERT_EQUAL_INT16(expected_big_endian, big_endian);
 }
 
-void test_long_to_big_endian()
+void test_int64_to_big_endian()
 {
-    LONG    small_endian                = 0x1234567890123456;
-    POINTER expected_big_endian_block_1 = 0x56341290;
-    POINTER expected_big_endian_block_2 = 0x78563412;
+    int64_t small_endian                = 0x1234567890123456;
+    int32_t expected_big_endian_block_1 = 0x56341290;
+    int32_t expected_big_endian_block_2 = 0x78563412;
 
-    LONG big_endian = math_long_to_big_endian(small_endian);
+    int64_t big_endian = math_int64_to_big_endian(small_endian);
     // Dirty hack: Enabling 64 bit support in unity (for TEST_ASSERT_EQUAL_INT64) causes segfaults when using any other assertion after!
-    POINTER block_1 = (big_endian & 0xffffffff00000000) >> 32;
-    POINTER block_2 = big_endian & 0xffffffff;
+    int32_t block_1 = (big_endian & 0xffffffff00000000) >> 32;
+    int32_t block_2 = big_endian & 0xffffffff;
 
     TEST_ASSERT_EQUAL_INT32(expected_big_endian_block_1, block_1);
     TEST_ASSERT_EQUAL_INT32(expected_big_endian_block_2, block_2);
 }
 
-void test_ptr_to_big_endian()
+void test_int32_to_big_endian()
 {
-    POINTER small_endian        = 0x12345678;
-    POINTER expected_big_endian = 0x78563412;
+    int32_t small_endian        = 0x12345678;
+    int32_t expected_big_endian = 0x78563412;
 
-    POINTER big_endian = math_ptr_to_big_endian(small_endian);
+    int32_t big_endian = math_int32_to_big_endian(small_endian);
 
     TEST_ASSERT_EQUAL_UINT32(expected_big_endian, big_endian);
 }
@@ -40,8 +40,8 @@ void test_ptr_to_big_endian()
 int main(void)
 {
     UNITY_BEGIN();
-    RUN_TEST(test_int_to_big_endian);
-    RUN_TEST(test_long_to_big_endian);
-    RUN_TEST(test_ptr_to_big_endian);
+    RUN_TEST(test_int16_to_big_endian);
+    RUN_TEST(test_int64_to_big_endian);
+    RUN_TEST(test_int32_to_big_endian);
     return UNITY_END();
 }

--- a/test/test_math.c
+++ b/test/test_math.c
@@ -1,0 +1,47 @@
+#include <unity.h>
+#include <vm/math.h>
+#include <vm/type.h>
+
+void test_int_to_big_endian()
+{
+    INTEGER small_endian        = 0x1234;
+    INTEGER expected_big_endian = 0x3412;
+
+    INTEGER big_endian = math_int_to_big_endian(small_endian);
+
+    TEST_ASSERT_EQUAL_INT16(expected_big_endian, big_endian);
+}
+
+void test_long_to_big_endian()
+{
+    LONG    small_endian                = 0x1234567890123456;
+    POINTER expected_big_endian_block_1 = 0x56341290;
+    POINTER expected_big_endian_block_2 = 0x78563412;
+
+    LONG big_endian = math_long_to_big_endian(small_endian);
+    // Dirty hack: Enabling 64 bit support in unity (for TEST_ASSERT_EQUAL_INT64) causes segfaults when using any other assertion after!
+    POINTER block_1 = (big_endian & 0xffffffff00000000) >> 32;
+    POINTER block_2 = big_endian & 0xffffffff;
+
+    TEST_ASSERT_EQUAL_INT32(expected_big_endian_block_1, block_1);
+    TEST_ASSERT_EQUAL_INT32(expected_big_endian_block_2, block_2);
+}
+
+void test_ptr_to_big_endian()
+{
+    POINTER small_endian        = 0x12345678;
+    POINTER expected_big_endian = 0x78563412;
+
+    POINTER big_endian = math_ptr_to_big_endian(small_endian);
+
+    TEST_ASSERT_EQUAL_UINT32(expected_big_endian, big_endian);
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_int_to_big_endian);
+    RUN_TEST(test_long_to_big_endian);
+    RUN_TEST(test_ptr_to_big_endian);
+    return UNITY_END();
+}


### PR DESCRIPTION
All bytecode can now only be in the big endian format. In little-endian platforms, the vm is compiled with the macro `VM_IS_LITTLE_ENDIAN`, which is used to ensure that ints are converted to little endian before being used.